### PR TITLE
Add persistence to reagent containers

### DIFF
--- a/modular_epoch/modules/persistence/code/reagent_containers.dm
+++ b/modular_epoch/modules/persistence/code/reagent_containers.dm
@@ -1,0 +1,17 @@
+/obj/item/reagent_containers/get_save_vars()
+	. = ..()
+	. += NAMEOF(src, amount_per_transfer_from_this)
+	. += NAMEOF(src, reagent_flags)
+	var/list/cached_reagents = reagent_list
+	var/list/reagents_to_save
+	if(cached_reagents.len)
+		for(var/datum/reagent/reagent as anything in cached_reagents)
+			var/amount = floor(reagent.volume) // integers are faster than decimals for saving and loading
+			if(amount)
+				LAZYSET(reagents_to_save, reagent.type, amount)
+
+	if(!compare_list(reagents_to_save, list_reagents)) // avoid redundant saving if lists match
+		list_reagents = reagents_to_save
+		. += NAMEOF(src, list_reagents)
+
+	return .

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6716,4 +6716,5 @@
 #include "interface\fonts\spess_font.dm"
 #include "interface\fonts\tiny_unicode.dm"
 #include "interface\fonts\vcr_osd_mono.dm"
+#include "modular_epoch\modules\persistence\code\reagent_containers.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This saves the reagents inside a container for things like, bottles, syringes, droppers, etc. It does not handle purity and the volume of a reagent is stored as an integer rounded down. (so `4.99999` becomes `4`, `3.25` becomes `3`, etc.) Storing them as integers should be a lot faster with map saving and loading.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Chemistry stuff being savable is useful. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Add persistence to reagent containers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
